### PR TITLE
refactor: use <Message>.createMessageComponentCollector instead of us…

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,9 @@
 {
-  "extends": ["prettier", "eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "extends": [
+    "prettier",
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
   "plugins": ["prettier", "@typescript-eslint"],
   "parser": "@typescript-eslint/parser"
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,17 +1,15 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Launch Program",
-            "skipFiles": [
-                "<node_internals>/**"
-            ],
-            "program": "${workspaceFolder}\\example\\bot.js"
-        }
-    ]
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "skipFiles": ["<node_internals>/**"],
+      "program": "${workspaceFolder}\\example\\bot.js"
+    }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ The displayed date is in the format `DD-MM-YYYY`
 
 [Older changelogs](#older-changelogs)
 
-## [v0.2.2]
+## [v0.3.0]
 
 > **Released:** `TBA`
+
+- Support yarn
+
+## [v0.2.2]
+
+> **Released:** `21-08-2021`
 
 ### Bug fixes
 
@@ -22,6 +28,14 @@ The displayed date is in the format `DD-MM-YYYY`
 
 - fix(Pagination): fix bug related to interactions. Only defer reply if not replied or deferred already
 - fix(Pagination): like when you provide button options, if you didn't provide either `back` or `next` or `page`. Then it would throw an error `Cannot read property 'label' of undefined`
+
+## [v0.2.0]
+
+> **Released:** `19-08-2021`
+
+### New features
+
+- feat: support yarn
 
 ## [v0.2.0]
 

--- a/example/bot.js
+++ b/example/bot.js
@@ -15,29 +15,34 @@ client.on("messageCreate", async (message) => {
     await client.application.commands.set([
         {
             name: "commands",
-            description: "Shows all commands!"
+            description: "Shows all commands!",
         },
         {
             name: "ping",
-            description: "Shows my ping!"
+            description: "Shows my ping!",
         },
         {
             name: "server",
-            description: "Show server's name"
-        }
+            description: "Show server's name",
+        },
     ]);
-})
+    message.reply("Done!");
+});
 client.on("interactionCreate", async (interaction) => {
     if (!interaction.isCommand()) return;
     const { commandName: cmd } = interaction;
 
     if (cmd === "commands") {
         const pages = [
-            (new MessageEmbed).setTitle("Page 1"),
-            (new MessageEmbed).setTitle("Page 2"),
+            new MessageEmbed().setTitle("Page 1"),
+            new MessageEmbed().setTitle("Page 2"),
         ];
-        pages[0].setDescription("To see my commands, go to the next page using buttons.");
-        pages[1].setDescription("My General commands\n```\n• commands - Shows all commands!\n• ping - Shows my ping!\n• server - Show server's name\n```");
+        pages[0].setDescription(
+            "To see my commands, go to the next page using buttons."
+        );
+        pages[1].setDescription(
+            "My General commands\n```\n• commands - Shows all commands!\n• ping - Shows my ping!\n• server - Show server's name\n```"
+        );
         const pagination = new Pagination(client);
         pagination.setPages(pages);
         pagination.setAuthorizedUsers([interaction.user.id]);
@@ -45,7 +50,9 @@ client.on("interactionCreate", async (interaction) => {
     } else if (cmd === "ping") {
         await interaction.reply(`Pong!\nMy latency: ${client.ws.ping}ms`);
     } else if (cmd === "server") {
-        await interaction.reply(`This server's name is ${interaction.guild.name}`);
+        await interaction.reply(
+            `This server's name is ${interaction.guild.name}`
+        );
     }
 });
 client.login(process.env.DISCORD_TOKEN);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "djs-pagination-buttons",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "djs-pagination-buttons",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "LGPL-2.1-only",
       "devDependencies": {
         "@types/node": "^16.4.10",
@@ -270,9 +270,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "version": "16.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.2.tgz",
+      "integrity": "sha512-LSw8TZt12ZudbpHc6EkIyDM3nHVWKYrAvGy6EAJfNfjusbwnThqjqxUKKRwuV3iWYeW/LYMzNgaq3MaLffQ2xA==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -2206,9 +2206,9 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.1.tgz",
-      "integrity": "sha512-JO1/nkMhUKb+Khiekn64HyBniuUuI3ePHN78BMiiFVHi4Oc8VqppWZiE2CNB38ZNqtwZFM+U3j0sJht3N6bWrg==",
+      "version": "0.22.3",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.3.tgz",
+      "integrity": "sha512-EOWf9Vf3Vfb/jzBzr87uoLybQw9fx3iyXLUcpQn9F2Ks1/ZJN9iGeBbYRU+VNqrWvV4T+aS7Ife7GFEJUf0ohQ==",
       "dev": true,
       "dependencies": {
         "glob": "^7.1.7",
@@ -2553,9 +2553,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "version": "16.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.2.tgz",
+      "integrity": "sha512-LSw8TZt12ZudbpHc6EkIyDM3nHVWKYrAvGy6EAJfNfjusbwnThqjqxUKKRwuV3iWYeW/LYMzNgaq3MaLffQ2xA==",
       "dev": true
     },
     "@types/ws": {
@@ -3935,9 +3935,9 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.1.tgz",
-      "integrity": "sha512-JO1/nkMhUKb+Khiekn64HyBniuUuI3ePHN78BMiiFVHi4Oc8VqppWZiE2CNB38ZNqtwZFM+U3j0sJht3N6bWrg==",
+      "version": "0.22.3",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.3.tgz",
+      "integrity": "sha512-EOWf9Vf3Vfb/jzBzr87uoLybQw9fx3iyXLUcpQn9F2Ks1/ZJN9iGeBbYRU+VNqrWvV4T+aS7Ife7GFEJUf0ohQ==",
       "dev": true,
       "requires": {
         "glob": "^7.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "djs-pagination-buttons",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Discord.js v13 pagination with buttons",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "publishPkg": "npm run build && npm publish --access=public",
+    "publishPkg": "npm run build && npm publish --access=public && npx yarn publish",
     "lint": "eslint src --ext .ts,.tsx,.js,.jsx",
     "format:check": "prettier --check .",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint src --ext .ts,.tsx,.js,.jsx",
     "format:check": "prettier --check .",
     "format": "prettier --write .",
-    "docs": "typedoc --options typedoc.json"
+    "docs": "typedoc --options typedoc.json",
+    "test": "node example/bot.js"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export * from "./types";
-export * from "./Pagination"
+export * from "./Pagination";

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export interface PaginationOptions {
             /** One of [MessageButtonStyleResolvable](https://discord.js.org/#/docs/main/master/typedef/MessageButtonStyleResolvable), default: `PRIMARY` */
             style: MessageButtonStyleResolvable;
         };
-        /** A disabled button which shows current page, default: `Page {{page}} / {{total_pages}}` */
+        /** A disabled button which shows current page, default: Page {{page}} / {{total_pages}} */
         page: string;
     };
     /** Time in milliseconds after which all buttons are disabled, default: `30000` (30 seconds) */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,12 @@
 {
-    "compilerOptions": {
-        "target": "ES6",
-        "module": "commonjs",
-        "declaration": true,
-        "outDir": "./lib",
-        "strict": true,
-        "strictNullChecks": false,
-        "esModuleInterop": true
-    },
-    "include": [
-        "src/**/*"
-    ]
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "./lib",
+    "strict": true,
+    "strictNullChecks": false,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,4 +1,4 @@
 {
-    "entryPoints": ["./src"],
-    "out": "docs"
+  "entryPoints": ["./src"],
+  "out": "docs"
 }


### PR DESCRIPTION
…ing event listeners

Using event listeners is bad which is only for a small period of time.
DJS devs told me to use <Message>.createMessageComponentCollector in these cases.
Using event listeners for these may leak memory.